### PR TITLE
Jima/threading fixup

### DIFF
--- a/concurrency-overview/io_asyncio.py
+++ b/concurrency-overview/io_asyncio.py
@@ -20,7 +20,7 @@ async def download_all_sites(sites):
 
 if __name__ == "__main__":
     sites = [
-        "http://www.jython.org",
+        "https://www.jython.org",
         "http://olympus.realpython.org/dice",
     ] * 80
     start_time = time.time()

--- a/concurrency-overview/io_mp.py
+++ b/concurrency-overview/io_mp.py
@@ -25,7 +25,7 @@ def download_all_sites(sites):
 
 if __name__ == "__main__":
     sites = [
-        "http://www.jython.org",
+        "https://www.jython.org",
         "http://olympus.realpython.org/dice",
     ] * 80
     start_time = time.time()

--- a/concurrency-overview/io_non_concurrent.py
+++ b/concurrency-overview/io_non_concurrent.py
@@ -16,7 +16,7 @@ def download_all_sites(sites):
 
 if __name__ == "__main__":
     sites = [
-        "http://www.jython.org",
+        "https://www.jython.org",
         "http://olympus.realpython.org/dice",
     ] * 80
     start_time = time.time()

--- a/concurrency-overview/io_threading.py
+++ b/concurrency-overview/io_threading.py
@@ -27,7 +27,7 @@ def download_all_sites(sites):
 
 if __name__ == "__main__":
     sites = [
-        "http://www.jython.org",
+        "https://www.jython.org",
         "http://olympus.realpython.org/dice",
     ] * 80
     start_time = time.time()

--- a/intro-to-threading/prodcom_lock.py
+++ b/intro-to-threading/prodcom_lock.py
@@ -4,7 +4,7 @@ import logging
 import random
 import threading
 
-SENTINEL = -1
+SENTINEL = object()
 
 
 class Pipeline:
@@ -51,9 +51,9 @@ def producer(pipeline):
 def consumer(pipeline):
     """ Pretend we're saving a number in the database. """
     message = 0
-    while message != SENTINEL:
+    while message is not SENTINEL:
         message = pipeline.get_message("Consumer")
-        if message != SENTINEL:
+        if message is not SENTINEL:
             logging.info("Consumer storing message: %s", message)
 
 


### PR DESCRIPTION
Changed the jython URL in the concurrency article and change to use `object()` for sentinel value in threading code examples.