### PR TITLE
flask-connexion-rest-part-2: update method of people.py might create duplicate people

### DIFF
--- a/flask-connexion-rest-part-2/version_1/people.py
+++ b/flask-connexion-rest-part-2/version_1/people.py
@@ -97,7 +97,7 @@ def create(person):
 def update(person_id, person):
     """
     This function updates an existing person in the people structure
-    Throws an error if a person with the name we want to update to 
+    Throws an error if a person with the name we want to update to
     already exists in the database.
 
     :param person_id:   Id of the person to update in the people structure
@@ -109,7 +109,7 @@ def update(person_id, person):
         Person.person_id == person_id
     ).one_or_none()
 
-    # Try to find an existing person with the same name that we want to update to
+    # Try to find an existing person with the same name as the update
     fname = person.get("fname")
     lname = person.get("lname")
 
@@ -126,8 +126,10 @@ def update(person_id, person):
             "Person not found for Id: {person_id}".format(person_id=person_id),
         )
 
-    # But would our update create a duplicate of another person that already exists?
-    elif existing_person is not None and existing_person.person_id != person_id:
+    # Would our update create a duplicate of another person already existing?
+    elif (
+        existing_person is not None and existing_person.person_id != person_id
+    ):
         abort(
             409,
             "Person {fname} {lname} exists already".format(

--- a/flask-connexion-rest-part-2/version_1/people.py
+++ b/flask-connexion-rest-part-2/version_1/people.py
@@ -145,7 +145,7 @@ def update(person_id, person):
         update = schema.load(person, session=db.session).data
 
         # Set the id to the person we want to update
-        update.id = update_person.person_id
+        update.person_id = update_person.person_id
 
         # merge the new object into the old and commit it to the db
         db.session.merge(update)

--- a/flask-connexion-rest-part-2/version_1/people.py
+++ b/flask-connexion-rest-part-2/version_1/people.py
@@ -97,6 +97,8 @@ def create(person):
 def update(person_id, person):
     """
     This function updates an existing person in the people structure
+    Throws an error if a person with the name we want to update to 
+    already exists in the database.
 
     :param person_id:   Id of the person to update in the people structure
     :param person:      person to update
@@ -107,8 +109,34 @@ def update(person_id, person):
         Person.person_id == person_id
     ).one_or_none()
 
-    # Did we find a person?
-    if update_person is not None:
+    # Try to find an existing person with the same name that we want to update to
+    fname = person.get("fname")
+    lname = person.get("lname")
+
+    existing_person = (
+        Person.query.filter(Person.fname == fname)
+        .filter(Person.lname == lname)
+        .one_or_none()
+    )
+
+    # Are we trying to find a person that does not exist?
+    if update_person is None:
+        abort(
+            404,
+            "Person not found for Id: {person_id}".format(person_id=person_id),
+        )
+
+    # But would our update create a duplicate of another person that already exists?
+    elif existing_person is not None and existing_person.person_id != person_id:
+        abort(
+            409,
+            "Person {fname} {lname} exists already".format(
+                fname=fname, lname=lname
+            ),
+        )
+
+    # Otherwise go ahead and update!
+    else:
 
         # turn the passed in person into a db object
         schema = PersonSchema()
@@ -125,13 +153,6 @@ def update(person_id, person):
         data = schema.dump(update_person).data
 
         return data, 200
-
-    # Otherwise, nope, didn't find that person
-    else:
-        abort(
-            404,
-            "Person not found for Id: {person_id}".format(person_id=person_id),
-        )
 
 
 def delete(person_id):


### PR DESCRIPTION
Hey RP folks,

When using your great(!) tutorial on flask-connexion-rest-APIs to start off my own project, I noticed that you specifically disallow creating a duplicate `person` in `people.create`, but still allow `person.update` to create duplicate people (by updating the `fname` and `lname` of `person_id` X to the `fname` and `lname` of `person_id` Y).

As the method is not explicitly described in the guide (at least not in part 2), I thought it would not add too much confusion on the reader's side to include a check that no conflicts will be created. 
I tried to match your code and comment style. This also created a lot of code duplication, but it seemed that this way it would be easier to read for the casual guidee.

Let me know if you think this is worth an addition, I am also happy to include the same fix in part one. 
I will leave the instructions below in for later reference, I have neither run your code style checks, nor tested that these changes won't break the app, yet.

Thanks :)

**How to merge your changes:** 
1. [Make sure the CI code style tests all pass.](https://github.com/realpython/materials/blob/master/README.md)
2. Find an RP Team member on Slack and ask them to review & approve your PR.
3. Once the PR has one positive ("approved") review, GitHub lets you merge the PR.
4. 🎉