### PR TITLE
Use consistent tag name ('people') across Version 2, 3 and 4

### DIFF
--- a/flask-connexion-rest/version_2/swagger.yml
+++ b/flask-connexion-rest/version_2/swagger.yml
@@ -16,7 +16,7 @@ paths:
     get:
       operationId: people.read
       tags:
-        - People
+        - people
       summary: The people data structure supported by the server application
       description: Read the list of people
       responses:

--- a/flask-connexion-rest/version_3/swagger.yml
+++ b/flask-connexion-rest/version_3/swagger.yml
@@ -16,7 +16,7 @@ paths:
     get:
       operationId: people.read_all
       tags:
-        - People
+        - people
       summary: Read the entire list of people
       description: Read the list of people
       parameters:

--- a/flask-connexion-rest/version_4/swagger.yml
+++ b/flask-connexion-rest/version_4/swagger.yml
@@ -16,7 +16,7 @@ paths:
     get:
       operationId: people.read_all
       tags:
-        - People
+        - people
       summary: Read the entire list of people
       description: Read the list of people
       parameters:
@@ -47,7 +47,7 @@ paths:
     post:
       operationId: people.create
       tags:
-        - People
+        - people
       summary: Create a person and add it to the people list
       description: Create a new person in the people list
       parameters:
@@ -72,7 +72,7 @@ paths:
     get:
       operationId: people.read_one
       tags:
-        - People
+        - people
       summary: Read one person from the people list
       description: Read one person from the people list
       parameters:
@@ -96,7 +96,7 @@ paths:
     put:
       operationId: people.update
       tags:
-        - People
+        - people
       summary: Update a person in the people list
       description: Update a person in the people list
       parameters:
@@ -121,7 +121,7 @@ paths:
     delete:
       operationId: people.delete
       tags:
-        - People
+        - people
       summary: Delete a person from the people list
       description: Delete a person
       parameters:


### PR DESCRIPTION
Version 3: Change tag of /people endpoint from 'People' to 'people'. This way, there is just one tag ('people') and all endpoints are bundled together in the Swagger UI.

**EDIT**: changed all occurrences of the tag 'People' to 'people' across all versions containing the swagger.yml file.