### PR TITLE
Make the GET tag to lower case

### DIFF
--- a/flask-connexion-rest/version_3/swagger.yml
+++ b/flask-connexion-rest/version_3/swagger.yml
@@ -16,7 +16,7 @@ paths:
     get:
       operationId: people.read_all
       tags:
-        - People
+        - people
       summary: Read the entire list of people
       description: Read the list of people
       parameters:


### PR DESCRIPTION
The swagger ui (/api/ui) groups the requests by tag. The groups are case sensitive. The tag at the GET request was capitalized, but at the rest requests the tag was all in lowercase.

I made the tag at the GET request to lowercase to match the rest


**Where to put new files:**

- New files should go into a top-level subfolder, named after the article slug. For example: `my-awesome-article`

**How to merge your changes:** 

1. [Make sure the CI code style tests all pass (+ run the automatic code formatter if necessary).](https://github.com/realpython/materials/blob/master/README.md)
2. Find an RP Team member on Slack and ask them to review & approve your PR.
3. Once the PR has one positive ("approved") review, GitHub lets you merge the PR.
4. 🎉
