### PR TITLE
Remove unnecessary email converter

### DIFF
--- a/pandas-gradebook-project/01-loading-the-data.py
+++ b/pandas-gradebook-project/01-loading-the-data.py
@@ -27,7 +27,7 @@ roster = pd.read_csv(
 
 hw_exam_grades = pd.read_csv(
     DATA_FOLDER / "hw_exam_grades.csv",
-    converters={"SID": str.lower, "Email Address": str.lower},
+    converters={"SID": str.lower},
     usecols=lambda x: "Submission" not in x,
     index_col="SID",
 )

--- a/pandas-gradebook-project/02-merging-dataframes.py
+++ b/pandas-gradebook-project/02-merging-dataframes.py
@@ -27,7 +27,7 @@ roster = pd.read_csv(
 
 hw_exam_grades = pd.read_csv(
     DATA_FOLDER / "hw_exam_grades.csv",
-    converters={"SID": str.lower, "Email Address": str.lower},
+    converters={"SID": str.lower},
     usecols=lambda x: "Submission" not in x,
     index_col="SID",
 )

--- a/pandas-gradebook-project/03-calculating-grades.py
+++ b/pandas-gradebook-project/03-calculating-grades.py
@@ -28,7 +28,7 @@ roster = pd.read_csv(
 
 hw_exam_grades = pd.read_csv(
     DATA_FOLDER / "hw_exam_grades.csv",
-    converters={"SID": str.lower, "Email Address": str.lower},
+    converters={"SID": str.lower},
     usecols=lambda x: "Submission" not in x,
     index_col="SID",
 )

--- a/pandas-gradebook-project/04-grouping-the-data.py
+++ b/pandas-gradebook-project/04-grouping-the-data.py
@@ -28,7 +28,7 @@ roster = pd.read_csv(
 
 hw_exam_grades = pd.read_csv(
     DATA_FOLDER / "hw_exam_grades.csv",
-    converters={"SID": str.lower, "Email Address": str.lower},
+    converters={"SID": str.lower},
     usecols=lambda x: "Submission" not in x,
     index_col="SID",
 )

--- a/pandas-gradebook-project/05-plotting-summary-statistics.py
+++ b/pandas-gradebook-project/05-plotting-summary-statistics.py
@@ -30,7 +30,7 @@ roster = pd.read_csv(
 
 hw_exam_grades = pd.read_csv(
     DATA_FOLDER / "hw_exam_grades.csv",
-    converters={"SID": str.lower, "Email Address": str.lower},
+    converters={"SID": str.lower},
     usecols=lambda x: "Submission" not in x,
     index_col="SID",
 )

--- a/pandas-gradebook-project/06-final-gradebook.py
+++ b/pandas-gradebook-project/06-final-gradebook.py
@@ -26,7 +26,7 @@ roster = pd.read_csv(
 
 hw_exam_grades = pd.read_csv(
     DATA_FOLDER / "hw_exam_grades.csv",
-    converters={"SID": str.lower, "Email Address": str.lower},
+    converters={"SID": str.lower},
     usecols=lambda x: "Submission" not in x,
     index_col="SID",
 )


### PR DESCRIPTION
The homework and exam grades don't have an Email Address column, so the
converter isn't necessary

**Where to put new files:**

- New files should go into a top-level subfolder, named after the article slug. For example: `my-awesome-article`

**How to merge your changes:** 

1. [Make sure the CI code style tests all pass (+ run the automatic code formatter if necessary).](https://github.com/realpython/materials/blob/master/README.md)
2. Find an RP Team member on Slack and ask them to review & approve your PR.
3. Once the PR has one positive ("approved") review, GitHub lets you merge the PR.
4. 🎉

From a [comment](http://disq.us/p/2ainbng) on the article, the `"Email Address"` converter for the `hw_exam_grades.csv` file is not needed and potentially confusing.
