### PR TITLE
[BUGFIX] Reference the global PEOPLE dict in create in people.py of connexion-v3

### DIFF
--- a/flask-connexion-rest/version_3/people.py
+++ b/flask-connexion-rest/version_3/people.py
@@ -74,6 +74,7 @@ def create(person):
     :param person:  person to create in people structure
     :return:        201 on success, 406 on person exists
     """
+    global PEOPLE
     lname = person.get("lname", None)
     fname = person.get("fname", None)
 


### PR DESCRIPTION
The creation is not persisted otherwise outside the function.

How to reproduce the associated bug:

- Use the API to create new record through its POST method.
- Use the people/{lname} API to fetch the newly added record.
- Nothing will be returned since the global `PEOPLE` dict has not been updated.