### PR TITLE
Fix inconsistent variable name in for-loop

### DIFF
--- a/django-diary/source_code_final/entries/templates/entries/entry_list.html
+++ b/django-diary/source_code_final/entries/templates/entries/entry_list.html
@@ -5,7 +5,7 @@
         <h2 class="mark">{% now "Y-m-d H:i" %}</em></h2>
         <a href="{% url 'entry-create' %}"><button>Add new entry</button></a>
     </article>
-    {% for entry in object_list %}
+    {% for entry in entry_list %}
         <article>
             <h2 class="{{ entry.date_created|date:'l' }}">
                 {{ entry.date_created|date:'Y-m-d H:i' }}

--- a/django-diary/source_code_step_4/entries/templates/entries/entry_list.html
+++ b/django-diary/source_code_step_4/entries/templates/entries/entry_list.html
@@ -1,7 +1,7 @@
 {% extends "entries/base.html" %}
 
 {% block content %}
-    {% for entry in object_list %}
+    {% for entry in entry_list %}
         <article>
             <h2 class="{{ entry.date_created|date:'l' }}">
                 {{ entry.date_created|date:'Y-m-d H:i' }}

--- a/django-diary/source_code_step_5/entries/templates/entries/entry_list.html
+++ b/django-diary/source_code_step_5/entries/templates/entries/entry_list.html
@@ -1,7 +1,7 @@
 {% extends "entries/base.html" %}
 
 {% block content %}
-    {% for entry in object_list %}
+    {% for entry in entry_list %}
         <article>
             <h2 class="{{ entry.date_created|date:'l' }}">
                 {{ entry.date_created|date:'Y-m-d H:i' }}

--- a/django-diary/source_code_step_6/entries/templates/entries/entry_list.html
+++ b/django-diary/source_code_step_6/entries/templates/entries/entry_list.html
@@ -5,7 +5,7 @@
         <h2 class="mark">{% now "Y-m-d H:i" %}</em></h2>
         <a href="{% url 'entry-create' %}"><button>Add new entry</button></a>
     </article>
-    {% for entry in object_list %}
+    {% for entry in entry_list %}
         <article>
             <h2 class="{{ entry.date_created|date:'l' }}">
                 {{ entry.date_created|date:'Y-m-d H:i' }}


### PR DESCRIPTION

In `django-diary/django-diary/source_code_*/entries/templates/entries/entry_list.html` there was an inconsistency in using `object_list` instead of `entry_list`. The fixes are already live in the CMS. This pull request updates the source code in the Materials repo accordingly.