### PR TITLE
Final QA edits of OpenAI DALL-E materials

### DIFF
--- a/openai-dalle/convert.py
+++ b/openai-dalle/convert.py
@@ -2,16 +2,16 @@ import json
 from base64 import b64decode
 from pathlib import Path
 
-JSON_FILE = Path("An ec-1668602437.json")
-IMAGE_DIR = Path.cwd() / "images" / JSON_FILE.stem
 DATA_DIR = Path.cwd() / "responses"
+JSON_FILE = DATA_DIR / "An ec-1667994848.json"
+IMAGE_DIR = Path.cwd() / "images" / JSON_FILE.stem
 
 IMAGE_DIR.mkdir(parents=True, exist_ok=True)
 
-with open(DATA_DIR / JSON_FILE, "r") as file:
+with open(JSON_FILE, mode="r", encoding="utf-8") as file:
     response = json.load(file)
 
 for index, image_dict in enumerate(response["data"]):
     image_data = b64decode(image_dict["b64_json"])
-    with open(IMAGE_DIR / f"{JSON_FILE.stem}-{index}.png", "wb") as png:
+    with open(IMAGE_DIR / f"{JSON_FILE.stem}-{index}.png", mode="wb") as png:
         png.write(image_data)

--- a/openai-dalle/edit.py
+++ b/openai-dalle/edit.py
@@ -14,8 +14,8 @@ DESTINATION_PATH.mkdir(parents=True, exist_ok=True)
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 response = openai.Image.create_edit(
-    image=open(SOURCE_PATH / "computer.png", "rb"),
-    mask=open(SOURCE_PATH / "mask.png", "rb"),
+    image=open(SOURCE_PATH / "computer.png", mode="rb"),
+    mask=open(SOURCE_PATH / "mask.png", mode="rb"),
     prompt=PROMPT,
     n=1,
     size="256x256",

--- a/openai-dalle/vary.py
+++ b/openai-dalle/vary.py
@@ -5,12 +5,12 @@ from pathlib import Path
 
 import openai
 
-SOURCE_FILE = "A com-1667994848.json"
 DATA_DIR = Path.cwd() / "responses"
+SOURCE_FILE = DATA_DIR / "An ec-1667994848.json"
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
-with open(DATA_DIR / SOURCE_FILE, "r") as json_file:
+with open(SOURCE_FILE, mode="r", encoding="utf-8") as json_file:
     saved_response = json.load(json_file)
     image_data = b64decode(saved_response["data"][0]["b64_json"])
 
@@ -21,7 +21,7 @@ response = openai.Image.create_variation(
     response_format="b64_json",
 )
 
-new_file_name = f"vary-{SOURCE_FILE[:4]}-{response['created']}.json"
+new_file_name = f"vary-{SOURCE_FILE.stem[:5]}-{response['created']}.json"
 
 with open(DATA_DIR / new_file_name, mode="w", encoding="utf-8") as file:
     json.dump(response, file)


### PR DESCRIPTION
@martin-martin Here are just a few suggested tweaks:

- consistently use `mode=` and `encoding="utf-8"` when opening files
- consistently use 5 letters from the prompt as prefix
- more consistent use of paths