### PR TITLE
Check for final newline in code files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,5 @@ target-version = "py312"
 exclude        = [".git", "venv", "migrations", "node_modules"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "RUF100"]
+select = ["E", "F", "I", "RUF100", "W292"]
 ignore = ["E501"]                  # Line length is controlled by Black


### PR DESCRIPTION
When selecting specific Ruff rules, I think we need to add W292 so that it checks for final newlines in code files.

(Might be that black is doing that in this dual setup, but maybe we can move towards using only ruff?)

We could also switch to Ruff entirely from my understanding:

```toml
target-version = "py313"
exclude = [
    ".git",
    "venv",
    ".venv",
    "migrations",
    "node_modules",
]

lint.select = [
    "E",
    "F",
    "I",
    "RUF100",
    "W292"
]

line-length = 79
```