### PR TITLE
Add example using 'with' statement and urlopen

### DIFF
--- a/context-managers/urlopen-example/with_urlopen_example.py
+++ b/context-managers/urlopen-example/with_urlopen_example.py
@@ -1,0 +1,16 @@
+
+"""
+Using the 'with' statement to open a URL
+
+This example demonstrates how Python's 'with' statement can be used
+to manage resources like HTTP connections when working with URLS
+"""
+
+from urllib.request import urlopen
+
+url = "https://www.python.org"
+
+# 'with' ensures that the connection automatically closes
+with urlopen(url) as response:
+    html = response.read()
+    print(html[:200]) # prints first 200 bytes


### PR DESCRIPTION
This pull request adds a beginner-friendly Python example to demonstrate the use of the `with` statement with `urllib.request.urlopen()` for safely opening and reading a URL. This addresses Issue #423.

The example is located in:
`context-managers/urlopen-example/with_urlopen_example.py`

It includes a simple script that fetches content from https://www.python.org and prints the first 200 bytes. The code also contains helpful comments for learners.
