### PR TITLE
Fix aiohttp ClientResponseError on twitter.com

### DIFF
--- a/understanding-asynchronous-programming/example_6.py
+++ b/understanding-asynchronous-programming/example_6.py
@@ -6,7 +6,8 @@ from codetiming import Timer
 
 async def task(name, work_queue):
     timer = Timer(text=f"Task {name} elapsed time: {{:.1f}}")
-    async with aiohttp.ClientSession() as session:
+    # default max_field_size=8190 is too low for Twitter's content-security-policy Header
+    async with aiohttp.ClientSession(max_field_size=16380) as session:
         while not work_queue.empty():
             url = await work_queue.get()
             print(f"Task {name} getting URL: {url}")


### PR DESCRIPTION
Fixes

aiohttp.client_exceptions.ClientResponseError:
400, message='Got more than 8190 bytes (10627) when reading Header value is too long.', url='https://twitter.com/'


**TODO** 

1. [Make sure the CI code style tests all pass (+ run the automatic code formatter if necessary).](https://github.com/realpython/materials/blob/master/README.md)
2. Find an RP Team member on Slack and ask them to review & approve your PR.
3. Once the PR has one positive ("approved") review, GitHub lets you merge the PR.
4. 🎉