### PR TITLE
Update Pydantic AI samples to non-deprecated google: model prefix

### DIFF
--- a/pydantic-ai/cats.py
+++ b/pydantic-ai/cats.py
@@ -2,7 +2,7 @@ import requests
 from pydantic_ai import Agent
 
 agent = Agent(
-    "google-gla:gemini-2.5-flash",
+    "google:gemini-2.5-flash",
     instructions="Help users with cat breeds. Be concise.",
 )
 

--- a/pydantic-ai/city.py
+++ b/pydantic-ai/city.py
@@ -9,7 +9,7 @@ class CityInfo(BaseModel):
     fun_fact: str
 
 
-agent = Agent("google-gla:gemini-2.5-flash", output_type=CityInfo)
+agent = Agent("google:gemini-2.5-flash", output_type=CityInfo)
 
 result = agent.run_sync("Tell me about Tokyo")
 print(result.output)

--- a/pydantic-ai/first_agent.py
+++ b/pydantic-ai/first_agent.py
@@ -1,7 +1,7 @@
 from pydantic_ai import Agent
 
 agent = Agent(
-    "google-gla:gemini-2.5-flash",
+    "google:gemini-2.5-flash",
     instructions="You're a Python Expert. Reply in one sentence.",
 )
 

--- a/pydantic-ai/users.py
+++ b/pydantic-ai/users.py
@@ -21,7 +21,7 @@ class UserSummary(BaseModel):
 
 
 agent = Agent(
-    "google-gla:gemini-2.5-flash",
+    "google:gemini-2.5-flash",
     output_type=UserSummary,
     deps_type=UserDatabase,
     instructions=(


### PR DESCRIPTION
## What

Update the Pydantic AI sample code to use the non-deprecated `google:` model prefix instead of `google-gla:`.

Pydantic AI renamed the Gemini API provider prefix. `google-gla:` still works in 1.x but now emits a `PydanticAIDeprecationWarning` and is removed in v2.0. The replacement for the free-tier Gemini API-key flow is `google:` (the `google-cloud:` prefix is the Vertex AI one, which these samples don't use). The `gemini-2.5-flash` model id is unchanged and still current on the Gemini API.

Per the [Pydantic AI docs](https://ai.pydantic.dev/models/google/):
> The `'google-gla:'` and `'google-vertex:'` prefixes still work in 1.x but emit a `DeprecationWarning`. Use `'google:'` and `'google-cloud:'` instead.

## Files changed

- `pydantic-ai/first_agent.py`
- `pydantic-ai/cats.py`
- `pydantic-ai/city.py`
- `pydantic-ai/users.py`

(`README.md` has no model references.)

## Context

This matches the corresponding fix applied to the *Pydantic AI: Build Type-Safe LLM Agents in Python* tutorial, and was flagged by a reader comment reporting the deprecation warning.
