### PR TITLE
Add python-mixins-course sample code

### DIFF
--- a/python-mixins-course/README.md
+++ b/python-mixins-course/README.md
@@ -1,0 +1,3 @@
+# Understanding Mixin Classes in Python
+
+This folder contains sample code for the Real Python video course [Understanding Mixin Classes in Python](https://realpython.com/courses/understanding-mixin-classes-in-python/).

--- a/python-mixins-course/as_dict_mixin.py
+++ b/python-mixins-course/as_dict_mixin.py
@@ -1,0 +1,22 @@
+class Person:
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
+
+    def as_dict(self):
+        return {
+            "name": self.name,
+            "age": self.age,
+        }
+
+
+class Car:
+    def __init__(self, make, model):
+        self.make = make
+        self.model = model
+
+    def as_dict(self):
+        return {
+            "make": self.make,
+            "model": self.model,
+        }

--- a/python-mixins-course/as_dict_mixin_final.py
+++ b/python-mixins-course/as_dict_mixin_final.py
@@ -1,0 +1,23 @@
+class AsDictMixin:
+    def as_dict(self):
+        return vars(self)
+
+
+class Person(AsDictMixin):
+    def __init__(self, name, age):
+        self.name = name
+        self.age = age
+
+
+john = Person("John", 42)
+print(john.as_dict())
+
+
+class Car(AsDictMixin):
+    def __init__(self, make, model):
+        self.make = make
+        self.model = model
+
+
+toyota = Car("Toyota", "Prius")
+print(toyota.as_dict())

--- a/python-mixins-course/sequence.py
+++ b/python-mixins-course/sequence.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class Sequence(ABC):
+    @abstractmethod
+    def __getitem__(self, index):
+        pass
+
+    @abstractmethod
+    def __len__(self):
+        pass

--- a/python-mixins-course/sequence_abc.py
+++ b/python-mixins-course/sequence_abc.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+
+
+class Sequence(ABC):
+    @abstractmethod
+    def __getitem__(self, index):
+        pass
+
+    @abstractmethod
+    def __len__(self):
+        pass
+
+    def __iter__(self):
+        index = 0
+        while index < len(self):
+            yield self[index]
+            index += 1
+
+
+class MyRange(Sequence):
+    def __init__(self, stop):
+        self.stop = stop  # Assume that `stop` is >= 0.
+
+    def __getitem__(self, index):
+        if 0 <= index < self.stop:
+            return index
+        raise IndexError
+
+    def __len__(self):
+        return self.stop
+
+
+r = MyRange(10)
+for number in r:
+    print(number)

--- a/python-mixins-course/sequence_final.py
+++ b/python-mixins-course/sequence_final.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+
+
+class Sequence(ABC):
+    @abstractmethod
+    def __getitem__(self, index):
+        pass
+
+    @abstractmethod
+    def __len__(self):
+        pass
+
+    def __iter__(self):
+        index = 0
+        while index < len(self):
+            yield self[index]
+            index += 1
+
+
+class MyRange(Sequence):
+    def __init__(self, stop):
+        self.stop = stop  # Assume that `stop` is >= 0.
+
+    def __getitem__(self, index):
+        if 0 <= index < self.stop:
+            return index
+        raise IndexError
+
+    def __len__(self):
+        return self.stop
+
+
+r = MyRange(10)
+for number in r:
+    print(number)

--- a/python-mixins-course/sequence_mixin.py
+++ b/python-mixins-course/sequence_mixin.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+
+
+class IterMixin:
+    # __iter__ works IF the class inheriting the mixin
+    # already provides __getitem__ and __len__.
+    def __iter__(self):
+        print("Hey from inside IterMixin.__iter__.")
+        index = 0
+        while index < len(self):
+            yield self[index]
+            index += 1
+
+
+class Sequence(IterMixin, ABC):
+    @abstractmethod
+    def __getitem__(self, index):
+        pass
+
+    @abstractmethod
+    def __len__(self):
+        pass
+
+
+class MyRange(Sequence):
+    def __init__(self, stop):
+        self.stop = stop  # Assume that `stop` is >= 0.
+
+    def __getitem__(self, index):
+        if 0 <= index < self.stop:
+            return index
+        raise IndexError
+
+    def __len__(self):
+        return self.stop
+
+
+r = MyRange(10)
+for number in r:
+    print(number)


### PR DESCRIPTION
## What

Adds `python-mixins-course/` — the sample code from the **[Understanding Mixin Classes in Python](https://realpython.com/courses/understanding-mixin-classes-in-python/)** video course.

## Why

The course's supporting code currently ships only as a members-only protected download. We want to offer it as a **free email opt-in** so the YouTube/free audience can get the exact code the video references (the existing `python-mixins/` folder is the *written tutorial's* code, which differs from the course's). Paired with CMS opt-in `mixin-classes-course-code`.

## Notes

- Flattened from the course zip's `materials/` folder; the six scripts are self-contained (only `from abc import ...`).
- `ruff format` + `ruff check` clean at the repo's `line-length = 79`; `dircheck.py` passes (folder name + README.md).
