### PR TITLE
Sample code for: Python HTTPX: Making HTTP Requests With HTTPX2

### DIFF
--- a/python-httpx/README.md
+++ b/python-httpx/README.md
@@ -1,0 +1,3 @@
+# Python HTTPX: Making HTTP Requests With HTTPX2
+
+This folder provides the code examples for the Real Python tutorial [Python HTTPX: Making HTTP Requests With HTTPX2](https://realpython.com/python-httpx/)

--- a/python-httpx/async_request.py
+++ b/python-httpx/async_request.py
@@ -1,0 +1,12 @@
+import asyncio
+
+import httpx2
+
+
+async def main():
+    async with httpx2.AsyncClient(base_url="https://api.github.com") as client:
+        response = await client.get("/events")
+        print(response.status_code)
+
+
+asyncio.run(main())

--- a/python-httpx/auth_header.py
+++ b/python-httpx/auth_header.py
@@ -1,0 +1,14 @@
+import httpx2
+
+with httpx2.Client(
+    base_url="https://api.github.com",
+    headers={
+        "Authorization": "Bearer your-token",
+        "Accept": "application/vnd.github+json",
+    },
+) as client:
+    first = client.get("/events")
+    second = client.get("/repos/python/cpython")
+
+print(first.status_code, second.status_code)
+print(second.request.headers["Accept"])

--- a/python-httpx/closed_client_error.py
+++ b/python-httpx/closed_client_error.py
@@ -1,0 +1,6 @@
+import httpx2
+
+with httpx2.Client() as client:
+    pass
+
+client.get("https://api.github.com/events")

--- a/python-httpx/custom_timeouts.py
+++ b/python-httpx/custom_timeouts.py
@@ -1,0 +1,7 @@
+import httpx2
+
+timeout = httpx2.Timeout(connect=5.0, read=10.0, write=None, pool=5.0)
+
+with httpx2.Client(timeout=timeout) as client:
+    response = client.get("https://api.github.com/events")
+    print(response.status_code)

--- a/python-httpx/default_timeout_error.py
+++ b/python-httpx/default_timeout_error.py
@@ -1,0 +1,3 @@
+import httpx2
+
+httpx2.get("https://httpbin.org/delay/6")

--- a/python-httpx/fetch_all.py
+++ b/python-httpx/fetch_all.py
@@ -1,0 +1,14 @@
+import asyncio
+
+import httpx2
+
+
+async def fetch_all(paths):
+    async with httpx2.AsyncClient(base_url="https://api.github.com") as client:
+        coroutines = [client.get(path) for path in paths]
+        responses = await asyncio.gather(*coroutines)
+        return [response.status_code for response in responses]
+
+
+paths = ["/events", "/repos/python/cpython", "/repos/psf/requests"]
+print(asyncio.run(fetch_all(paths)))

--- a/python-httpx/first_request.py
+++ b/python-httpx/first_request.py
@@ -1,0 +1,5 @@
+import httpx2
+
+response = httpx2.get("https://api.github.com/events")
+print(response.status_code)
+print(response.json())

--- a/python-httpx/handle_errors.py
+++ b/python-httpx/handle_errors.py
@@ -1,0 +1,20 @@
+import httpx2
+
+timeout = httpx2.Timeout(5.0)
+
+with httpx2.Client(timeout=timeout) as client:
+    try:
+        response = client.get("https://api.github.com/nonexistent")
+        response.raise_for_status()
+    except httpx2.ConnectTimeout:
+        print("Timed out while connecting to the host.")
+    except httpx2.ReadTimeout:
+        print("Timed out while receiving data from the host.")
+    except httpx2.WriteTimeout:
+        print("Timed out while sending data to the host.")
+    except httpx2.PoolTimeout:
+        print("Timed out waiting for a pool connection.")
+    except httpx2.HTTPStatusError as error:
+        print(f"Bad response: {error.response.status_code}")
+    except httpx2.RequestError as error:
+        print(f"A network problem occurred: {error}")

--- a/python-httpx/handle_errors_async.py
+++ b/python-httpx/handle_errors_async.py
@@ -1,0 +1,26 @@
+import asyncio
+
+import httpx2
+
+
+async def main():
+    timeout = httpx2.Timeout(5.0)
+    async with httpx2.AsyncClient(timeout=timeout) as client:
+        try:
+            response = await client.get("https://api.github.com/nonexistent")
+            response.raise_for_status()
+        except httpx2.ConnectTimeout:
+            print("Timed out while connecting to the host.")
+        except httpx2.ReadTimeout:
+            print("Timed out while receiving data from the host.")
+        except httpx2.WriteTimeout:
+            print("Timed out while sending data to the host.")
+        except httpx2.PoolTimeout:
+            print("Timed out waiting for a pool connection.")
+        except httpx2.HTTPStatusError as error:
+            print(f"Bad response: {error.response.status_code}")
+        except httpx2.RequestError as error:
+            print(f"A network problem occurred: {error}")
+
+
+asyncio.run(main())

--- a/python-httpx/http2_client.py
+++ b/python-httpx/http2_client.py
@@ -1,0 +1,5 @@
+import httpx2
+
+with httpx2.Client(http2=True) as client:
+    response = client.get("https://api.github.com/events")
+    print(response.http_version)

--- a/python-httpx/post_request.py
+++ b/python-httpx/post_request.py
@@ -1,0 +1,9 @@
+import httpx2
+
+with httpx2.Client() as client:
+    response = client.post(
+        "https://httpbin.org/post",
+        json={"title": "New issue", "body": "Found a bug"},
+    )
+    print(response.status_code)
+    print(response.json()["json"])

--- a/python-httpx/requests_version.py
+++ b/python-httpx/requests_version.py
@@ -1,0 +1,5 @@
+import requests
+
+response = requests.get("https://api.github.com/events")
+print(response.status_code)
+print(response.json())

--- a/python-httpx/requirements.txt
+++ b/python-httpx/requirements.txt
@@ -1,0 +1,2 @@
+httpx2[http2]==2.12.0
+requests==2.34.2

--- a/python-httpx/reusable_client.py
+++ b/python-httpx/reusable_client.py
@@ -1,0 +1,9 @@
+import httpx2
+
+with httpx2.Client(base_url="https://api.github.com") as client:
+    first = client.get("/events")
+    second = client.get(
+        "/repos/python/cpython/issues",
+        params={"state": "open", "per_page": 5},
+    )
+print(first.status_code, second.status_code)

--- a/python-httpx/stream_download.py
+++ b/python-httpx/stream_download.py
@@ -1,0 +1,9 @@
+import httpx2
+
+with httpx2.Client() as client:
+    with client.stream(
+        "GET", "https://httpbin.org/stream-bytes/102400"
+    ) as response:
+        print(response.headers)
+        for chunk in response.iter_bytes(chunk_size=1024):
+            print(f"Received {len(chunk)} bytes")

--- a/python-httpx/timeout_fires.py
+++ b/python-httpx/timeout_fires.py
@@ -1,0 +1,9 @@
+import httpx2
+
+timeout = httpx2.Timeout(1.0)
+
+with httpx2.Client(timeout=timeout) as client:
+    try:
+        client.get("https://httpbin.org/delay/3")
+    except httpx2.ReadTimeout:
+        print("The request timed out.")


### PR DESCRIPTION
**Where to put new files:**

- New files should go into a top-level subfolder, named after the article slug. For example: `my-awesome-article`

**How to merge your changes:** 

1. [Make sure the CI code style tests all pass (+ run the automatic code formatter if necessary).](https://github.com/realpython/materials/blob/master/README.md)
2. Find an RP Team member on Slack and ask them to review & approve your PR.
3. Once the PR has one positive ("approved") review, GitHub lets you merge the PR.
4. 🎉

---

Code examples for the [Python HTTPX: Making HTTP Requests With HTTPX2](https://realpython.com/python-httpx/) tutorial. Files live in the `python-httpx/` top-level folder, named after the article slug.

Generated from the tutorial markdown with the `post-materials` skill, then verified locally before pushing. Every file was executed against `httpx2` 2.12.0: the thirteen named examples each reproduce the output documented in the article, and `default_timeout_error.py` and `closed_client_error.py` raise the exceptions the troubleshooting section describes.

Two notes on the contents:

- `requirements.txt` pins `httpx2[http2]` so `http2_client.py` works out of the box. The tutorial installs the extra later on, once it reaches the HTTP/2 section.
- The tutorial's fourth error demo — calling `httpx2.Client(http2=True)` without the `http2` extra — isn't included, since it can't raise from a folder whose requirements install that extra.
