### PR TITLE
Sample code for: Python 3.15 Preview: Sentinel Values

### DIFF
--- a/python315-sentinel-values/README.md
+++ b/python315-sentinel-values/README.md
@@ -1,0 +1,3 @@
+# Python 3.15 Preview: Sentinel Values
+
+This folder provides the code examples for the Real Python tutorial [Python 3.15 Preview: Sentinel Values](https://realpython.com/python315-sentinel-values/)

--- a/python315-sentinel-values/config.py
+++ b/python315-sentinel-values/config.py
@@ -1,0 +1,8 @@
+UNSET = sentinel("UNSET")
+INHERIT = sentinel("INHERITED")  # Made a typo in the variable name
+
+
+class Config:
+    AUTO = sentinel("Config.AUTO")
+    # Some code here...
+    NO_LIMIT = sentinel("NO_LIMIT")  # Forgot the qualified name

--- a/python315-sentinel-values/example_001.py
+++ b/python315-sentinel-values/example_001.py
@@ -1,0 +1,1 @@
+print("Hello, World!".find("z"))

--- a/python315-sentinel-values/example_002.py
+++ b/python315-sentinel-values/example_002.py
@@ -1,0 +1,9 @@
+import configparser
+import inspect
+import typing
+import unittest.mock
+
+print(configparser._UNSET)
+print(inspect.Parameter.empty)
+print(typing.NoDefault)
+print(unittest.mock.DEFAULT)

--- a/python315-sentinel-values/example_003.py
+++ b/python315-sentinel-values/example_003.py
@@ -1,0 +1,7 @@
+import pickle
+from copy import deepcopy
+
+_MISSING = object()
+print(_MISSING)
+print(deepcopy(_MISSING) is _MISSING)
+print(pickle.loads(pickle.dumps(_MISSING)) is _MISSING)

--- a/python315-sentinel-values/example_004.py
+++ b/python315-sentinel-values/example_004.py
@@ -1,0 +1,4 @@
+grades = {"Jane": 90, "John": None}
+print(grades.get("John") is grades.get("Linda"))
+print("Pythonista!".find("z"))
+print("Pythonista!"["Pythonista!".find("z")])

--- a/python315-sentinel-values/example_005.py
+++ b/python315-sentinel-values/example_005.py
@@ -1,0 +1,11 @@
+from copy import deepcopy
+
+
+class _MissingType:
+    def __repr__(self):
+        return "MISSING"
+
+
+MISSING = _MissingType()
+print(MISSING)
+print(deepcopy(MISSING) is MISSING)

--- a/python315-sentinel-values/example_006.py
+++ b/python315-sentinel-values/example_006.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class MissingType(enum.Enum):
+    MISSING = "MISSING"
+
+
+print(MissingType.MISSING)

--- a/python315-sentinel-values/example_007.py
+++ b/python315-sentinel-values/example_007.py
@@ -1,0 +1,2 @@
+MISSING = sentinel("MISSING")
+print(MISSING)

--- a/python315-sentinel-values/example_008.py
+++ b/python315-sentinel-values/example_008.py
@@ -1,0 +1,2 @@
+UNSET = sentinel("UNSET", repr="<unset>")
+print(UNSET)

--- a/python315-sentinel-values/example_009.py
+++ b/python315-sentinel-values/example_009.py
@@ -1,0 +1,10 @@
+# Both calls intentionally fail. Catch each error so you can see both.
+try:
+    sentinel("UNSET", "<unset>")
+except TypeError as error:
+    print(f"Expected TypeError: {error}")
+
+try:
+    sentinel(name="UNSET")
+except TypeError as error:
+    print(f"Expected TypeError: {error}")

--- a/python315-sentinel-values/example_010.py
+++ b/python315-sentinel-values/example_010.py
@@ -1,0 +1,7 @@
+MISSING = sentinel("MISSING")
+print(bool(MISSING))
+print(hash(MISSING))
+config = {MISSING: "unset", "timeout": 30}
+print(config[MISSING])
+print(MISSING in {MISSING, 1, 2})
+print(MISSING == sentinel("MISSING"))

--- a/python315-sentinel-values/example_011.py
+++ b/python315-sentinel-values/example_011.py
@@ -1,0 +1,1 @@
+print(sentinel("STOP") is sentinel("STOP"))

--- a/python315-sentinel-values/example_012.py
+++ b/python315-sentinel-values/example_012.py
@@ -1,0 +1,6 @@
+A = sentinel("A")
+B = sentinel("B")
+print(type(A) is type(B))
+print(isinstance(A, sentinel))
+print(isinstance(B, sentinel))
+print(A is B)

--- a/python315-sentinel-values/example_013.py
+++ b/python315-sentinel-values/example_013.py
@@ -1,0 +1,5 @@
+from copy import copy, deepcopy
+
+MISSING = sentinel("MISSING")
+print(copy(MISSING) is MISSING)
+print(deepcopy(MISSING) is MISSING)

--- a/python315-sentinel-values/example_014.py
+++ b/python315-sentinel-values/example_014.py
@@ -1,0 +1,11 @@
+import pickle
+from config import Config, INHERIT, UNSET
+
+print(pickle.loads(pickle.dumps(UNSET)) is UNSET)
+print(pickle.loads(pickle.dumps(Config.AUTO)) is Config.AUTO)
+# These names intentionally don't match their module/class bindings.
+for value in (INHERIT, Config.NO_LIMIT):
+    try:
+        pickle.dumps(value)
+    except pickle.PicklingError as error:
+        print(f"Expected PicklingError: {error}")

--- a/python315-sentinel-values/example_015.py
+++ b/python315-sentinel-values/example_015.py
@@ -1,0 +1,6 @@
+import inspect
+
+from settings_legacy import get_setting
+
+help(get_setting)
+print(inspect.signature(get_setting))

--- a/python315-sentinel-values/example_016.py
+++ b/python315-sentinel-values/example_016.py
@@ -1,0 +1,6 @@
+import inspect
+
+from settings_sentinel import get_setting
+
+help(get_setting)
+print(inspect.signature(get_setting))

--- a/python315-sentinel-values/example_017.py
+++ b/python315-sentinel-values/example_017.py
@@ -1,0 +1,5 @@
+import typing
+from settings_typed_legacy import get_setting
+
+hints = typing.get_type_hints(get_setting)
+print(hints["default"])

--- a/python315-sentinel-values/example_018.py
+++ b/python315-sentinel-values/example_018.py
@@ -1,0 +1,5 @@
+import typing
+from settings_typed_sentinel import get_setting
+
+hints = typing.get_type_hints(get_setting)
+print(hints["default"])

--- a/python315-sentinel-values/example_019.py
+++ b/python315-sentinel-values/example_019.py
@@ -1,0 +1,9 @@
+from profiles_legacy import apply_patch, parse_patch
+
+patch = parse_patch({"name": "jane", "bio": None})
+profile = {
+    "name": "J. Doe",
+    "bio": "Data scientist",
+    "email": "jane@example.com",
+}
+print(apply_patch(profile, patch))

--- a/python315-sentinel-values/example_019.py
+++ b/python315-sentinel-values/example_019.py
@@ -1,9 +1,9 @@
 from profiles_legacy import apply_patch, parse_patch
 
-patch = parse_patch({"name": "jane", "bio": None})
 profile = {
     "name": "J. Doe",
     "bio": "Data scientist",
     "email": "jane@example.com",
 }
+patch = parse_patch({"name": "jane", "bio": None})
 print(apply_patch(profile, patch))

--- a/python315-sentinel-values/example_020.py
+++ b/python315-sentinel-values/example_020.py
@@ -1,0 +1,5 @@
+from copy import deepcopy
+from profiles_legacy import _MISSING, parse_patch
+
+patch = parse_patch({"name": "jane", "bio": None})
+print(deepcopy(patch)["email"] is _MISSING)

--- a/python315-sentinel-values/example_021.py
+++ b/python315-sentinel-values/example_021.py
@@ -1,0 +1,5 @@
+import pickle
+from profiles_legacy import _MISSING, parse_patch
+
+patch = parse_patch({"name": "jane", "bio": None})
+print(pickle.loads(pickle.dumps(patch))["email"] is _MISSING)

--- a/python315-sentinel-values/example_022.py
+++ b/python315-sentinel-values/example_022.py
@@ -1,0 +1,7 @@
+import pickle
+from copy import deepcopy
+from profiles_sentinel import MISSING, parse_patch
+
+patch = parse_patch({"name": "jane", "bio": None})
+print(deepcopy(patch)["email"] is MISSING)
+print(pickle.loads(pickle.dumps(patch))["email"] is MISSING)

--- a/python315-sentinel-values/example_023.py
+++ b/python315-sentinel-values/example_023.py
@@ -1,0 +1,15 @@
+STOP = "done"
+
+
+def producer():
+    words = ["ready", "done", "pending"]  # Simulate produced words
+    for word in words:
+        yield word
+    yield STOP
+
+
+words_stream = producer()
+for word in words_stream:
+    if word == STOP:
+        break
+    print(f"Processing '{word}'...")

--- a/python315-sentinel-values/example_024.py
+++ b/python315-sentinel-values/example_024.py
@@ -10,6 +10,6 @@ def producer():
 
 words_stream = producer()
 for word in words_stream:
-    if word == STOP:
+    if word is STOP:
         break
     print(f"Processing '{word}'...")

--- a/python315-sentinel-values/example_024.py
+++ b/python315-sentinel-values/example_024.py
@@ -1,0 +1,15 @@
+STOP = sentinel("STOP")
+
+
+def producer():
+    words = ["ready", "done", "pending"]
+    for word in words:
+        yield word
+    yield STOP
+
+
+words_stream = producer()
+for word in words_stream:
+    if word == STOP:
+        break
+    print(f"Processing '{word}'...")

--- a/python315-sentinel-values/missing.py
+++ b/python315-sentinel-values/missing.py
@@ -1,0 +1,21 @@
+class _MissingType:
+    def __init__(self, name):
+        self._name = name
+
+    def __repr__(self):
+        return self._name
+
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
+
+    def __reduce__(self):
+        return self._name
+
+    def __eq__(self, other):
+        return self is other
+
+    def __hash__(self):
+        return id(self)

--- a/python315-sentinel-values/profiles_legacy.py
+++ b/python315-sentinel-values/profiles_legacy.py
@@ -1,0 +1,15 @@
+# Python 3.14 and older approach
+_MISSING = object()
+
+
+def parse_patch(form):
+    fields = ("name", "bio", "email")
+    return {field: form.get(field, _MISSING) for field in fields}
+
+
+def apply_patch(profile, patch):
+    updated = dict(profile)
+    for field, value in patch.items():
+        if value is not _MISSING:
+            updated[field] = value
+    return updated

--- a/python315-sentinel-values/profiles_sentinel.py
+++ b/python315-sentinel-values/profiles_sentinel.py
@@ -1,0 +1,15 @@
+# Python 3.15 or newer
+MISSING = sentinel("MISSING")
+
+
+def parse_patch(form):
+    fields = ("name", "bio", "email")
+    return {field: form.get(field, MISSING) for field in fields}
+
+
+def apply_patch(profile, patch):
+    updated = dict(profile)
+    for field, value in patch.items():
+        if value is not MISSING:
+            updated[field] = value
+    return updated

--- a/python315-sentinel-values/ruff.toml
+++ b/python315-sentinel-values/ruff.toml
@@ -1,0 +1,4 @@
+extend = "../pyproject.toml"
+
+# The repository's pinned Ruff predates Python 3.15's sentinel built-in.
+builtins = ["sentinel"]

--- a/python315-sentinel-values/sentinel_type.py
+++ b/python315-sentinel-values/sentinel_type.py
@@ -1,0 +1,2 @@
+# Python 3.15 or newer
+print(sentinel)

--- a/python315-sentinel-values/settings_legacy.py
+++ b/python315-sentinel-values/settings_legacy.py
@@ -1,0 +1,14 @@
+# Python 3.14 and older approach
+_NO_DEFAULT = object()
+
+
+def get_setting(config, path, default=_NO_DEFAULT):
+    current = config
+    for part in path.split("."):
+        try:
+            current = current[part]
+        except (KeyError, TypeError):
+            if default is _NO_DEFAULT:
+                raise KeyError(path) from None
+            return default
+    return current

--- a/python315-sentinel-values/settings_sentinel.py
+++ b/python315-sentinel-values/settings_sentinel.py
@@ -1,0 +1,14 @@
+# Python 3.15 or newer
+NO_DEFAULT = sentinel("NO_DEFAULT")
+
+
+def get_setting(config, path, default=NO_DEFAULT):
+    current = config
+    for part in path.split("."):
+        try:
+            current = current[part]
+        except (KeyError, TypeError):
+            if default is NO_DEFAULT:
+                raise KeyError(path) from None
+            return default
+    return current

--- a/python315-sentinel-values/settings_typed_legacy.py
+++ b/python315-sentinel-values/settings_typed_legacy.py
@@ -1,0 +1,18 @@
+# Python 3.14 and older approach, with type hints
+_NO_DEFAULT = object()
+
+
+def get_setting(
+    config: dict[str, object],
+    path: str,
+    default: object = _NO_DEFAULT,
+) -> str | int:
+    current = config
+    for part in path.split("."):
+        try:
+            current = current[part]
+        except (KeyError, TypeError):
+            if default is _NO_DEFAULT:
+                raise KeyError(path) from None
+            return default
+    return current

--- a/python315-sentinel-values/settings_typed_sentinel.py
+++ b/python315-sentinel-values/settings_typed_sentinel.py
@@ -1,0 +1,18 @@
+# Python 3.15 or newer, with type hints
+NO_DEFAULT = sentinel("NO_DEFAULT")
+
+
+def get_setting(
+    config: dict[str, object],
+    path: str,
+    default: str | int | NO_DEFAULT = NO_DEFAULT,
+) -> str | int:
+    current = config
+    for part in path.split("."):
+        try:
+            current = current[part]
+        except (KeyError, TypeError):
+            if default is NO_DEFAULT:
+                raise KeyError(path) from None
+            return default
+    return current


### PR DESCRIPTION
**Where to put new files:**

- New files should go into a top-level subfolder, named after the article slug. For example: `my-awesome-article`

**How to merge your changes:** 

1. [Make sure the CI code style tests all pass (+ run the automatic code formatter if necessary).](https://github.com/realpython/materials/blob/master/README.md)
2. Find an RP Team member on Slack and ask them to review & approve your PR.
3. Once the PR has one positive ("approved") review, GitHub lets you merge the PR.
4. 🎉

---

Sample code for [Python 3.15 Preview: Sentinel Values](https://realpython.com/python315-sentinel-values/), in the `python315-sentinel-values/` folder.

Includes 33 Python files covering legacy sentinel patterns, Python 3.15's built-in `sentinel`, function signatures, type hints, copying, pickling, and loop termination. Legacy and Python 3.15 implementations use separate module names so each example runs independently. Intentional error demonstrations catch and print the expected exceptions.

Extracted from the tutorial with the post-materials skill, adapted into standalone scripts, and verified locally. All 33 files run on Python 3.15.0b3. Settings lookup/default/error behavior and the key identity and loop outputs were also checked.

The folder-local Ruff configuration inherits the repository rules and declares `sentinel` as a built-in because the pinned Ruff 0.14.1 predates Python 3.15. REPL imports are placed at the top of the extracted scripts.
